### PR TITLE
Add `.get()` that returns the computed value of the element

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ css(element, {
     top: 0,
     position: 'absolute'
 })
+
+//get the computed value
+css.get(element, 'position') // >> absolute
+css.get(element, ['left', 'top']) // >> {left: '25px', top: '0px'}
 ``` 
 
 See the [special cases](#special-cases) for a list of `px`-suffixed properties (same list is used in GreenSock API).

--- a/index.js
+++ b/index.js
@@ -18,9 +18,12 @@ function style(element, property, value) {
     var camel = cache[property]
     if (typeof camel === 'undefined')
         camel = detect(property)
-    
+
     //may be false if CSS prop is unsupported
-    if (camel) { 
+    if (camel) {
+        if (value === undefined)
+            return element.style[camel]
+
         if (typeof value === 'number')
             value = value + (suffixMap[camel]||'')
         element.style[camel] = value
@@ -42,10 +45,26 @@ function detect(cssProp) {
     return result
 }
 
-module.exports = function() {
+function set() {
     'use strict';
     if (arguments.length === 2) {
         each(arguments[0], arguments[1])
     } else
         style(arguments[0], arguments[1], arguments[2])
+}
+
+module.exports = set
+module.exports.set = set
+
+module.exports.get = function(element, properties) {
+    if (typeof properties === 'string') {
+        return style(element, properties)
+    }
+
+    var values = {}
+    properties.forEach(function(property) {
+        values[property] = style(element, property)
+    })
+
+    return values
 }

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ test('handles multiple', function(t) {
     var prefixed = prefix('fontSmoothing')
     if (prefixed) //webkit only test
         t.equal(style[prefixed], 'none', 'hanldes prefixing')
-    
+
     css(div, 'marginTop', 20)
     css(div, 'width', '') //clears a style
     style = window.getComputedStyle(div, null)
@@ -54,7 +54,7 @@ test('transforms', function(t) {
     if (prefix('transform')) {
         var width = div.getBoundingClientRect().width
         t.equal(width, 100, 'starts with 100px')
-        
+
         css(div, 'transform', 'translateZ(10px)')
         width = div.getBoundingClientRect().width
         t.equal(width, 100, 'still 100px after translateZ')
@@ -71,6 +71,26 @@ test('transforms', function(t) {
     }
 
     css(div, 'left', '50%')
+
+    document.body.removeChild(div)
+    t.end()
+})
+
+test('computed value', function(t) {
+    var div = document.createElement('div')
+    css(div, {
+        marginTop: 10,
+        width: 20
+    })
+
+    document.body.appendChild(div)
+
+    t.deepEqual(css.get(div, 'width'), '20px', 'single value')
+    t.deepEqual(
+        css.get(div, ['width', 'marginTop']),
+        {width: '20px', marginTop: '10px'},
+        'multiple values'
+    )
 
     document.body.removeChild(div)
     t.end()


### PR DESCRIPTION
Hey,

I have added the `.get()` function that returns the computed value the the element.

When I set a property with `dom-css` I expect to be able to get its value (or another one). 
Especially when I set a prefixed property. Otherwise I need use another module to get the prefixed property and use `element.style[]` or `.getComputedStyle()`.

IMO it makes sense to be able to set and get elements' properties in the same module.

I tried to respect your style guide, let me know if I've missed something :)

Thanks.
