### PR TITLE
removing 'use strict'; line

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ function detect(cssProp) {
 }
 
 function set() {
-    'use strict';
     if (arguments.length === 2) {
         each(arguments[0], arguments[1])
     } else


### PR DESCRIPTION
hey, thanks for this module, super handy! Just ran into a confusing issue where it would say `each` wasn't defined in chrome when using this with webpack module hot loading. Presumably it's because webpack will use `eval` to isolate code blocks during dev builds and according to this: http://whereswalden.com/2011/01/10/new-es5-strict-mode-support-new-vars-created-by-strict-mode-eval-code-are-local-to-that-code-only/ that means `eval`'ed `use strict` code can't create variable outside of its scope.

Additionally weird is that the error would only appear with devtools closed. 

All that said, here was the end result:

https://cloudup.com/cwzFJUJo8sH

Anyway, if there wasn't a particular reason for having the `'use strict'` statement here, i figured i'd offer to remove it since this resolved the issue for me and possibly someone else using webpack would have similar issues.
